### PR TITLE
feat: add devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Debian",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			"nodeGypDependencies": true,
+			"version": "lts",
+			"nvmVersion": "latest"
+		},
+		"ghcr.io/shyim/devcontainers-features/bun:0": {},
+		"ghcr.io/devcontainers-community/features/deno:1": {
+			"version": "latest"
+		}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+* text eol=lf
 *.json  linguist-language=JSON-with-Comments


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/h3/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This allows developers on Windows to open the project in VS Code using a Docker container that runs Debian, including Node, Deno, Bun.

```
vscode ➜ /workspaces/h3 $ bun --version
1.0.16
vscode ➜ /workspaces/h3 $ node --version
v20.10.0
vscode ➜ /workspaces/h3 $ deno --version
deno 1.38.5 (release, x86_64-unknown-linux-gnu)
v8 12.0.267.1
typescript 5.2.2
```

Is able to run the tests without issues using `npm run test`

### Linked Issues

#25 

### Additional context

All files where 'changed' in git, because I first opened in Windows before creating the devcontainer. Adding extra config to `.gitattributes` to specify line endings.