### PR TITLE
fix: locale polluted by cross request

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -73,6 +73,8 @@ describe('useTranslation', () => {
     const bindLocaleDetector = (locale as LocaleDetector).bind(null, eventMock)
     // @ts-ignore ignore type error because this is test
     context.locale = bindLocaleDetector
+    // @ts-ignore ignore type error because this is test
+    eventMock.context.i18nLocale = bindLocaleDetector
 
     // test `useTranslation`
     const t = await useTranslation(eventMock)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -74,7 +74,7 @@ describe('useTranslation', () => {
     // @ts-ignore ignore type error because this is test
     context.locale = bindLocaleDetector
     // @ts-ignore ignore type error because this is test
-    eventMock.context.i18nLocale = bindLocaleDetector
+    eventMock.context._i18nLocale = bindLocaleDetector
 
     // test `useTranslation`
     const t = await useTranslation(eventMock)

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ import type {
 declare module 'h3' {
   interface H3EventContext {
     i18n?: CoreContext
-    i18nLocale?: LocaleDetector
+    _i18nLocale?: LocaleDetector
   }
 }
 
@@ -136,8 +136,8 @@ export function defineI18nMiddleware<
 
   return {
     onRequest(event: H3Event) {
-      event.context.i18nLocale = getLocaleDetector(event, i18n as CoreContext)
-      i18n.locale = event.context.i18nLocale
+      event.context._i18nLocale = getLocaleDetector(event, i18n as CoreContext)
+      i18n.locale = event.context._i18nLocale
       event.context.i18n = i18n as CoreContext
     },
     onAfterResponse(event: H3Event) {
@@ -357,7 +357,7 @@ export async function useTranslation<
     )
   }
 
-  const localeDetector = event.context.i18nLocale as unknown as LocaleDetector
+  const localeDetector = event.context._i18nLocale as unknown as LocaleDetector
   let locale: string
   if (localeDetector.constructor.name === 'AsyncFunction') {
     locale = await localeDetector(event)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/h3/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Currently, when there are two concurrent requests with two different locales, the locale of the first locale would be overridden by the second request because they share the same i18n context but in different h3 event context.  This PR fix it by binding the locale of h3 event to `translate` function.

#### Before

<img width="820" alt="image" src="https://github.com/user-attachments/assets/ce537c85-5c6e-42f4-96ec-504af612c439">

#### After

Test pass ✅

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
